### PR TITLE
Make F an Fer

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -84,8 +84,17 @@ func init() {
 
 }
 
+var (
+	_ Fer = F{} // ensure F is an Fer
+)
+
 // F is a key-value mapping for structured data.
 type F map[string]interface{}
+
+// F ields for logging
+func (f F) F() map[string]interface{} {
+	return f
+}
 
 type Fer interface {
 	F() map[string]interface{}
@@ -111,21 +120,22 @@ func (l *Logger) Log(p Priority, xs ...interface{}) {
 	addF := func(bf F) {
 		if event.Data == nil {
 			event.Data = bf
-		} else {
-			for k, v := range bf {
-				event.Data[k] = v
-			}
+			return
+		}
+		for k, v := range bf {
+			event.Data[k] = v
 		}
 	}
 
 	// Assemble the event
 	for _, b := range xs {
-		if bf, ok := b.(F); ok {
-			addF(bf)
-		} else if fer, ok := b.(Fer); ok {
-			addF(F(fer.F()))
-		} else {
-			bits = append(bits, b)
+		switch t := b.(type) {
+		case F:
+			addF(t)
+		case Fer:
+			addF(t.F())
+		default:
+			bits = append(bits, t)
 		}
 	}
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 )
 
-func setup(t *testing.T) (*bytes.Buffer, func()) {
-	out := bytes.Buffer{}
+func setup() (*bytes.Buffer, func()) {
+	var out bytes.Buffer
 	oldFilters := DefaultLogger.Filters
 	DefaultLogger.Filters = []Filter{NewWriterFilter(&out, nil)}
 	return &out, func() {
@@ -17,7 +17,7 @@ func setup(t *testing.T) (*bytes.Buffer, func()) {
 }
 
 func TestSimpleError(t *testing.T) {
-	out, teardown := setup(t)
+	out, teardown := setup()
 	defer teardown()
 
 	Info(F{"err": fmt.Errorf("This is an Error!!!")}, "fooey", F{"bar": "foo"})
@@ -35,7 +35,7 @@ func TestSimpleError(t *testing.T) {
 }
 
 func TestTimeConversion(t *testing.T) {
-	out, teardown := setup(t)
+	out, teardown := setup()
 	defer teardown()
 
 	var zeroTime time.Time
@@ -53,12 +53,11 @@ func TestTimeConversion(t *testing.T) {
 }
 
 func TestDebug(t *testing.T) {
-	out, teardown := setup(t)
+	out, teardown := setup()
 	defer teardown()
 
 	oldPri := DefaultLogger.Pri
 	defer func() { DefaultLogger.Pri = oldPri }()
-
 
 	// set priority to Debug
 	DefaultLogger.Pri = PriDebug
@@ -79,7 +78,7 @@ func TestDebug(t *testing.T) {
 }
 
 func TestFer(t *testing.T) {
-	out, teardown := setup(t)
+	out, teardown := setup()
 	defer teardown()
 
 	underTest := foobar{Foo: 1, Bar: "quux"}
@@ -103,7 +102,7 @@ type foobar struct {
 }
 
 func (f foobar) F() map[string]interface{} {
-	return map[string]interface{} {
+	return map[string]interface{}{
 		"foo": f.Foo,
 		"bar": f.Bar,
 	}


### PR DESCRIPTION
This way a slice of Fer's can be assembled that includes an ln.F, which can makes
it easier to log a few of them at once. Example:

    func SomeOp(a,b,c inputs, fers ...ln.Fer) {
		if err := doStuff(a,b,c); err != nil {
			fers := append([]ln.Fer{ln.F{"a":a,"b":b,"c":c"}}, fers...)
			ln.Error(fers)
		}
	}

Also some misc style changes