### PR TITLE
add context support

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -1,23 +1,24 @@
 package ln
 
 import (
+	"context"
 	"io"
 	"sync"
 )
 
 // Filter interface for defining chain filters
 type Filter interface {
-	Apply(Event) bool
+	Apply(ctx context.Context, e Event) bool
 	Run()
 	Close()
 }
 
 // FilterFunc allows simple functions to implement the Filter interface
-type FilterFunc func(e Event) bool
+type FilterFunc func(ctx context.Context, e Event) bool
 
 // Apply implements the Filter interface
-func (ff FilterFunc) Apply(e Event) bool {
-	return ff(e)
+func (ff FilterFunc) Apply(ctx context.Context, e Event) bool {
+	return ff(ctx, e)
 }
 
 // Run implements the Filter interface
@@ -45,8 +46,8 @@ func NewWriterFilter(out io.Writer, format Formatter) *WriterFilter {
 }
 
 // Apply implements the Filter interface
-func (w *WriterFilter) Apply(e Event) bool {
-	output, err := w.Formatter.Format(e)
+func (w *WriterFilter) Apply(ctx context.Context, e Event) bool {
+	output, err := w.Formatter.Format(ctx, e)
 	if err == nil {
 		w.Lock()
 		w.Out.Write(output)
@@ -63,4 +64,4 @@ func (w *WriterFilter) Run() {}
 func (w *WriterFilter) Close() {}
 
 // NilFilter is safe to return as a Filter, but does nothing
-var NilFilter = FilterFunc(func(e Event) bool { return true })
+var NilFilter = FilterFunc(func(_ context.Context, e Event) bool { return true })

--- a/formatter.go
+++ b/formatter.go
@@ -2,6 +2,7 @@ package ln
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"time"
 )
@@ -13,7 +14,7 @@ var (
 
 // Formatter defines the formatting of events
 type Formatter interface {
-	Format(Event) ([]byte, error)
+	Format(ctx context.Context, e Event) ([]byte, error)
 }
 
 // DefaultFormatter is the default way in which to format events
@@ -36,7 +37,7 @@ func NewTextFormatter() Formatter {
 }
 
 // Format implements the Formatter interface
-func (t *TextFormatter) Format(e Event) ([]byte, error) {
+func (t *TextFormatter) Format(_ context.Context, e Event) ([]byte, error) {
 	var writer bytes.Buffer
 
 	writer.WriteString("time=\"")

--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,7 @@
 package ln
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -109,7 +110,7 @@ type Event struct {
 }
 
 // Log is the generic logging method.
-func (l *Logger) Log(p Priority, xs ...interface{}) {
+func (l *Logger) Log(ctx context.Context, p Priority, xs ...interface{}) {
 	if l.Pri < p {
 		return // don't log
 	}
@@ -151,95 +152,95 @@ func (l *Logger) Log(p Priority, xs ...interface{}) {
 		event.Data["_filename"] = frame.filename
 	}
 
-	l.filter(event)
+	l.filter(ctx, event)
 }
 
-func (l *Logger) filter(e Event) {
+func (l *Logger) filter(ctx context.Context, e Event) {
 	for _, f := range l.Filters {
-		if !f.Apply(e) {
+		if !f.Apply(ctx, e) {
 			return
 		}
 	}
 }
 
 // Emergency sets the priority of this event to PriEmergency
-func (l *Logger) Emergency(xs ...interface{}) {
-	l.Log(PriEmergency, xs...)
+func (l *Logger) Emergency(ctx context.Context, xs ...interface{}) {
+	l.Log(ctx, PriEmergency, xs...)
 }
 
 // Alert sets the priority of this event to PriAlert
-func (l *Logger) Alert(xs ...interface{}) {
-	l.Log(PriAlert, xs...)
+func (l *Logger) Alert(ctx context.Context, xs ...interface{}) {
+	l.Log(ctx, PriAlert, xs...)
 }
 
 // Critical sets the priority of this event to PriCritical
-func (l *Logger) Critical(xs ...interface{}) {
-	l.Log(PriCritical, xs...)
+func (l *Logger) Critical(ctx context.Context, xs ...interface{}) {
+	l.Log(ctx, PriCritical, xs...)
 }
 
 // Error sets the priority of this event to PriError
-func (l *Logger) Error(xs ...interface{}) {
-	l.Log(PriError, xs...)
+func (l *Logger) Error(ctx context.Context, xs ...interface{}) {
+	l.Log(ctx, PriError, xs...)
 }
 
 // Warning sets the priority of this event to PriWarning
-func (l *Logger) Warning(xs ...interface{}) {
-	l.Log(PriWarning, xs...)
+func (l *Logger) Warning(ctx context.Context, xs ...interface{}) {
+	l.Log(ctx, PriWarning, xs...)
 }
 
 // Notice sets the priority of this event to PriNotice
-func (l *Logger) Notice(xs ...interface{}) {
-	l.Log(PriNotice, xs...)
+func (l *Logger) Notice(ctx context.Context, xs ...interface{}) {
+	l.Log(ctx, PriNotice, xs...)
 }
 
 // Info sets the priority of this event to PriInfo
-func (l *Logger) Info(xs ...interface{}) {
-	l.Log(PriInfo, xs...)
+func (l *Logger) Info(ctx context.Context, xs ...interface{}) {
+	l.Log(ctx, PriInfo, xs...)
 }
 
 // Debug sets the priority of this event to PriDebug
-func (l *Logger) Debug(xs ...interface{}) {
-	l.Log(PriDebug, xs...)
+func (l *Logger) Debug(ctx context.Context, xs ...interface{}) {
+	l.Log(ctx, PriDebug, xs...)
 }
 
 // Default Implementation
 
 // Emergency sets the priority of this event to PriEmergency
-func Emergency(xs ...interface{}) {
-	DefaultLogger.Log(PriEmergency, xs...)
+func Emergency(ctx context.Context, xs ...interface{}) {
+	DefaultLogger.Log(ctx, PriEmergency, xs...)
 }
 
 // Alert sets the priority of this event to PriAlert
-func Alert(xs ...interface{}) {
-	DefaultLogger.Log(PriAlert, xs...)
+func Alert(ctx context.Context, xs ...interface{}) {
+	DefaultLogger.Log(ctx, PriAlert, xs...)
 }
 
 // Critical sets the priority of this event to PriCritical
-func Critical(xs ...interface{}) {
-	DefaultLogger.Log(PriCritical, xs...)
+func Critical(ctx context.Context, xs ...interface{}) {
+	DefaultLogger.Log(ctx, PriCritical, xs...)
 }
 
 // Error sets the priority of this event to PriError
-func Error(xs ...interface{}) {
-	DefaultLogger.Log(PriError, xs...)
+func Error(ctx context.Context, xs ...interface{}) {
+	DefaultLogger.Log(ctx, PriError, xs...)
 }
 
 // Warning sets the priority of this event to PriWarning
-func Warning(xs ...interface{}) {
-	DefaultLogger.Log(PriWarning, xs...)
+func Warning(ctx context.Context, xs ...interface{}) {
+	DefaultLogger.Log(ctx, PriWarning, xs...)
 }
 
 // Notice sets the priority of this event to PriNotice
-func Notice(xs ...interface{}) {
-	DefaultLogger.Log(PriNotice, xs...)
+func Notice(ctx context.Context, xs ...interface{}) {
+	DefaultLogger.Log(ctx, PriNotice, xs...)
 }
 
 // Info sets the priority of this event to PriInfo
-func Info(xs ...interface{}) {
-	DefaultLogger.Log(PriInfo, xs...)
+func Info(ctx context.Context, xs ...interface{}) {
+	DefaultLogger.Log(ctx, PriInfo, xs...)
 }
 
 // Debug sets the priority of this event to PriDebug
-func Debug(xs ...interface{}) {
-	DefaultLogger.Log(PriDebug, xs...)
+func Debug(ctx context.Context, xs ...interface{}) {
+	DefaultLogger.Log(ctx, PriDebug, xs...)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -2,12 +2,17 @@ package ln
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 	"time"
 )
 
+var ctx context.Context
+
 func setup() (*bytes.Buffer, func()) {
+	ctx = context.Background()
+
 	var out bytes.Buffer
 	oldFilters := DefaultLogger.Filters
 	DefaultLogger.Filters = []Filter{NewWriterFilter(&out, nil)}
@@ -20,7 +25,7 @@ func TestSimpleError(t *testing.T) {
 	out, teardown := setup()
 	defer teardown()
 
-	Info(F{"err": fmt.Errorf("This is an Error!!!")}, "fooey", F{"bar": "foo"})
+	Info(ctx, F{"err": fmt.Errorf("This is an Error!!!")}, "fooey", F{"bar": "foo"})
 	data := []string{
 		`err="This is an Error!!!"`,
 		`fooey`,
@@ -40,7 +45,7 @@ func TestTimeConversion(t *testing.T) {
 
 	var zeroTime time.Time
 
-	Info(F{"zero": zeroTime})
+	Info(ctx, F{"zero": zeroTime})
 	data := []string{
 		`zero=0001-01-01T00:00:00Z`,
 	}
@@ -61,7 +66,7 @@ func TestDebug(t *testing.T) {
 
 	// set priority to Debug
 	DefaultLogger.Pri = PriDebug
-	Debug(F{"err": fmt.Errorf("This is an Error!!!")})
+	Debug(ctx, F{"err": fmt.Errorf("This is an Error!!!")})
 
 	data := []string{
 		`err="This is an Error!!!"`,
@@ -83,7 +88,7 @@ func TestFer(t *testing.T) {
 
 	underTest := foobar{Foo: 1, Bar: "quux"}
 
-	Info(underTest)
+	Info(ctx, underTest)
 	data := []string{
 		`foo=1`,
 		`bar=quux`,


### PR DESCRIPTION
This allows for easy creation of context-aware logging filters without having to pass the context as a "magic" value (kind of like `err` currently is XXX). The main aim of this API breaking change is to allow ln log entries to automagically have all of their values added to opentracing spans.

This will need changes to `ln-roll` and other packages that depend on `ln`.
This change breaks the public API (for good reasons!).